### PR TITLE
spark to duckdb

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
     <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
-    <squashql.version>1.16.1</squashql.version>
+    <squashql.version>1.16.2</squashql.version>
     <spring-boot.version>3.0.11</spring-boot.version>
     <junit.version>5.9.1</junit.version>
     <junit-platform.version>1.9.1</junit-platform.version>
@@ -35,7 +35,7 @@
     </dependency>
     <dependency>
       <groupId>io.squashql</groupId>
-      <artifactId>squashql-spark</artifactId>
+      <artifactId>squashql-duckdb</artifactId>
       <version>${squashql.version}</version>
     </dependency>
     <dependency>

--- a/src/main/java/io/squashql/spring/DBController.java
+++ b/src/main/java/io/squashql/spring/DBController.java
@@ -1,7 +1,6 @@
 package io.squashql.spring;
 
 import io.squashql.ShowcaseApplication;
-import io.squashql.SparkDatastore;
 import io.squashql.query.database.QueryEngine;
 import io.squashql.store.Datastore;
 import io.squashql.store.Store;
@@ -63,7 +62,7 @@ public class DBController {
 
   @PostMapping("/upload")
   public ResponseEntity<String> uploadFile(@RequestParam("file") MultipartFile file, @RequestParam String table) throws IOException {
-    ShowcaseApplication.loadFile((QueryEngine<SparkDatastore>) engine, table, file.getInputStream());
+    ShowcaseApplication.loadFile(this.engine, table, file.getInputStream());
     return ResponseEntity.status(HttpStatus.OK).body("File uploaded successfully: " + file.getOriginalFilename());
   }
 }

--- a/ts/package.json
+++ b/ts/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@squashql/squashql-codegen": "1.0.17",
-    "@squashql/squashql-js": "1.16.1",
+    "@squashql/squashql-js": "1.16.2",
     "lodash": "^4.17.21"
   }
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@antv/s2-react": "^1.46.1",
     "@duckdb/duckdb-wasm": "^1.28.1-dev106.0",
-    "@squashql/squashql-js": "1.16.1",
+    "@squashql/squashql-js": "1.16.2",
     "bootstrap": "^5.3.2",
     "bootstrap-icons": "^1.11.3",
     "next": "14.1.0",


### PR DESCRIPTION
The problem with DuckDB has been fixed in 0.10.1 release. This PR reverts the previous change https://github.com/squashql/squashql-showcase/commit/87edd93feee2c6f4064b942b4a677a96487a760b#diff-8a21e7dab342e9ae46b44bae8a8db5a795dcbb00e45229685eb2bf118f797a62